### PR TITLE
Add the use_sha256 config option.

### DIFF
--- a/apex/models.py
+++ b/apex/models.py
@@ -4,9 +4,11 @@ import string
 import transaction
 
 from cryptacular.bcrypt import BCRYPTPasswordManager
+from cryptacular.crypt import CRYPTPasswordManager, SHA256CRYPT
 
 from pyramid.threadlocal import get_current_request
 from pyramid.util import DottedNameResolver
+from pyramid.settings import asbool
 
 from sqlalchemy import (Column,
                         ForeignKey,
@@ -181,9 +183,15 @@ class AuthUser(Base):
     # how do we handle same auth on multiple ids?
 
     def _set_password(self, password):
+        request = get_current_request()
+        use_sha256 = asbool(request.registry.settings.get('apex.use_sha256'))
+
         self.salt = self.get_salt(24)
-        password = password + self.salt
-        self._password = BCRYPTPasswordManager().encode(password, rounds=12)
+        if use_sha256:
+            self._password = CRYPTPasswordManager(SHA256CRYPT).encode(password)
+        else:
+            password = password + self.salt
+            self._password = BCRYPTPasswordManager().encode(password, rounds=12)
 
     def _get_password(self):
         return self._password
@@ -248,22 +256,30 @@ class AuthUser(Base):
         if kwargs.has_key('login'):
             user = cls.get_by_login(kwargs['login'])
 
+        request = get_current_request()
+        use_sha256 = asbool(request.registry.settings.get('apex.use_sha256'))
+
         if not user:
             return False
+
         try:
-            if BCRYPTPasswordManager().check(user.password,
-                '%s%s' % (kwargs['password'], user.salt)):
-                return True
+            if use_sha256:
+                pw = kwargs['password']
+                if CRYPTPasswordManager(SHA256CRYPT).check(user.password, pw):
+                    return True
+            else:
+                pw = kwargs['password'] + user.salt
+                if BCRYPTPasswordManager().check(user.password, pw):
+                    return True
         except TypeError:
             pass
 
-        request = get_current_request()
         fallback_auth = request.registry.settings.get('apex.fallback_auth')
         if fallback_auth:
             resolver = DottedNameResolver(fallback_auth.split('.', 1)[0])
             fallback = resolver.resolve(fallback_auth)
-            return fallback().check(DBSession, request, user, \
-                       kwargs['password'])
+            pw = kwargs['password']
+            return fallback().check(DBSession, request, user, pw)
 
         return False
 

--- a/docs/source/options.rst
+++ b/docs/source/options.rst
@@ -37,6 +37,10 @@ apex.use_recaptcha_on_auth = false
 apex.exclude_local = false
   OPTIONAL, disable local authentication
 
+apex.use_sha256 = false
+  OPTIONAL, force use of a SHA256 hash to store passwords instead of the
+  default encode method from cryptacular.bcrypt.BCRYPTPasswordManager.
+
 apex.velruse_providers = 
   OPTIONAL, comma separated list to include velruse configured providers.
 


### PR DESCRIPTION
Force the use of the SHA256 hash for password storage instead of relying on
the default algorithm from BCRYPTPasswordManager.  This option forces
consistency with the current values in the database tables but may not
be the best available algorithm on a given system.
