### PR TITLE
docs: fix simple typo, requred -> required

### DIFF
--- a/apex/decorators.py
+++ b/apex/decorators.py
@@ -6,7 +6,7 @@ from pyramid.url import route_url
 from apex.lib.flash import flash
 
 def login_required(wrapped):
-    """ login_requred - Decorator to be used if you don't want to use
+    """ login_required - Decorator to be used if you don't want to use
     permission='user'
     """
     def wrapper(request):


### PR DESCRIPTION
There is a small typo in apex/decorators.py.

Should read `required` rather than `requred`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md